### PR TITLE
Add affine, xproj and rasterix in the conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,8 @@ dependencies:
 - xarray
 - netcdf4
 - dask
+- affine
+- xproj
+- pip
+- pip:
+  - rasterix


### PR DESCRIPTION
Adds the dependencies `affine`, `xproj` and `rasterix` in the `environment.yml` file.