### PR TITLE
Remove duplicate ndim property in GDALBackendArray class

### DIFF
--- a/gdx/gdx.py
+++ b/gdx/gdx.py
@@ -62,11 +62,7 @@ class GDALBackendArray(BackendArray):
     @property
     def size(self):
         return np.prod(self._shape)
-    
-    @property
-    def ndim(self):
-        return len(self._shape)
-    
+
     def __getitem__(self, key):
         # Handle xarray's explicit indexing objects
         from xarray.core import indexing as xr_indexing


### PR DESCRIPTION
The ndim property was defined twice in the GDALBackendArray class (lines 59-61 and 67-69). This commit removes the duplicate definition to clean up the code.